### PR TITLE
Add support for crossorigin attribute in script and link tags

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 1.7.0
 =====
 
-Release the last major version of django-pipeline working on Python 2.
+* Release the last major version of django-pipeline working on Python 2.
 * Thank you for all the modifications made since version 1.6.14, which we cannot quote.
 * Apply an optimization to save time during development. Thank to @blankser
 * Edit setup.py to follow the recommendation of the documentation. Thank to @shaneikennedy

--- a/pipeline/forms.py
+++ b/pipeline/forms.py
@@ -136,7 +136,7 @@ class PipelineFormMediaMetaClass(type):
         # If we define any packages, we'll need to use our special
         # PipelineFormMediaProperty class. We use this instead of intercepting
         # in __getattribute__ because Django does not access them through
-        # normal properpty access. Instead, grabs the Media class's __dict__
+        # normal property access. Instead, grabs the Media class's __dict__
         # and accesses them from there. By using these special properties, we
         # can handle direct access (Media.css) and dictionary-based access
         # (Media.__dict__['css']).

--- a/pipeline/templates/pipeline/css.html
+++ b/pipeline/templates/pipeline/css.html
@@ -1,1 +1,1 @@
-<link href="{{ url }}" rel="stylesheet" type="{{ type }}" media="{{ media|default:"all" }}"{% if title %} title="{{ title }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />
+<link href="{{ url }}" rel="stylesheet" type="{{ type }}" media="{{ media|default:"all" }}"{% if crossorigin %} crossorigin="{{ crossorigin }}"{% endif %}{% if title %} title="{{ title }}"{% endif %}{% if charset %} charset="{{ charset }}"{% endif %} />

--- a/pipeline/templates/pipeline/js.html
+++ b/pipeline/templates/pipeline/js.html
@@ -1,1 +1,1 @@
-<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"></script>
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8"{% if crossorigin %} crossorigin="{{ crossorigin }}"{% endif %}></script>


### PR DESCRIPTION
The `crossorigin` attribute is useful in `script` and `link` tags provides support for CORS. 

From the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin):

> The crossorigin attribute, valid on the <audio>, <img>, <link>, <script>, and <video> elements, provides support for CORS, defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.

Refer to [this html spec document](https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute) for more information.